### PR TITLE
Marked more strings as translatable, fixed typos

### DIFF
--- a/Kernel/Config/Files/OTRSAppointmentCalendar.xml
+++ b/Kernel/Config/Files/OTRSAppointmentCalendar.xml
@@ -6,8 +6,8 @@
         <SubGroup>Frontend::Public::ModuleRegistration</SubGroup>
         <Setting>
             <FrontendModuleReg>
-                <Description>PublicCalendar</Description>
-                <Title>PublicCalendar</Title>
+                <Description Translatable="1">Public calendar.</Description>
+                <Title Translatable="1">Public Calendar</Title>
                 <NavBarName></NavBarName>
             </FrontendModuleReg>
         </Setting>
@@ -339,7 +339,7 @@
         </Setting>
     </ConfigItem>
     <ConfigItem Name="AppointmentCalendar::Import::RecurringMonthsLimit" Required="1" Valid="1">
-        <Description Translatable="1">OTRS doesn't support recurring Appointments without end date or number of iterrations. During import process, it might happen that ICS file contains such Appointments. Instead, system creates all Appointments in the past, plus Appointments for the next n months(120 months/10 years by default).</Description>
+        <Description Translatable="1">OTRS doesn't support recurring Appointments without end date or number of iterations. During import process, it might happen that ICS file contains such Appointments. Instead, system creates all Appointments in the past, plus Appointments for the next n months (120 months/10 years by default).</Description>
         <Group>OTRSAppointmentCalendar</Group>
         <SubGroup>Core::AppointmentCalendar</SubGroup>
         <Setting>

--- a/Kernel/Modules/AgentAppointmentCalendarManage.pm
+++ b/Kernel/Modules/AgentAppointmentCalendarManage.pm
@@ -113,7 +113,7 @@ sub Run {
         if ( !%Calendar ) {
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('System was unable to create Calendar!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -131,7 +131,7 @@ sub Run {
         if ( !$GetParam{CalendarID} ) {
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('No CalendarID!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -146,7 +146,7 @@ sub Run {
             # fake message
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('You have no access to this calendar!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -232,7 +232,7 @@ sub Run {
         if ( !$Success ) {
             return $LayoutObject->ErrorScreen(
                 Message => Translatable('Error updating the calendar!'),
-                Comment => Translatable('Please contact the admin.'),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
 
@@ -260,8 +260,8 @@ sub Run {
         my $CalendarData = $Kernel::OM->Get('Kernel::System::YAML')->Load( Data => $Content );
         if ( ref $CalendarData ne 'HASH' ) {
             return $LayoutObject->ErrorScreen(
-                Message =>
-                    "Couldn't read calendar configuration file. Please make sure your file is valid.",
+                Message => Translatable('Couldn\'t read calendar configuration file.'),
+                Comment => Translatable('Please make sure your file is valid.'),
             );
         }
 

--- a/Kernel/Modules/AgentAppointmentTeam.pm
+++ b/Kernel/Modules/AgentAppointmentTeam.pm
@@ -111,7 +111,7 @@ sub Run {
                 $Self->_Overview();
                 my $Output = $LayoutObject->Header();
                 $Output .= $LayoutObject->NavigationBar();
-                $Output .= $LayoutObject->Notify( Info => 'Team updated!' );
+                $Output .= $LayoutObject->Notify( Info => Translatable('Team updated!') );
                 $Output .= $LayoutObject->Output(
                     TemplateFile => 'AgentAppointmentTeam',
                     Data         => \%Param,
@@ -202,7 +202,7 @@ sub Run {
                 $Self->_Overview();
                 my $Output = $LayoutObject->Header();
                 $Output .= $LayoutObject->NavigationBar();
-                $Output .= $LayoutObject->Notify( Info => 'Team added!' );
+                $Output .= $LayoutObject->Notify( Info => Translatable('Team added!') );
                 $Output .= $LayoutObject->Output(
                     TemplateFile => 'AgentAppointmentTeam',
                     Data         => \%Param,
@@ -251,8 +251,8 @@ sub Run {
         my $TeamData = $Kernel::OM->Get('Kernel::System::YAML')->Load( Data => $Content );
         if ( ref $TeamData ne 'HASH' ) {
             return (
-                Message =>
-                    "Couldn't read team configuration file. Please make sure you file is valid.",
+                Message => Translatable('Couldn\'t read team configuration file.'),
+                Comment => Translatable('Please make sure you file is valid.'),
             );
         }
 
@@ -270,7 +270,7 @@ sub Run {
             $Output .= $LayoutObject->NavigationBar();
             $Output .= $LayoutObject->Notify(
                 Priority => 'Error',
-                Info     => 'Could not import the team!'
+                Info     => Translatable('Could not import the team!'),
             );
             $Output .= $LayoutObject->Output(
                 TemplateFile => 'AgentAppointmentTeam',
@@ -284,7 +284,7 @@ sub Run {
             $Self->_Overview();
             my $Output = $LayoutObject->Header();
             $Output .= $LayoutObject->NavigationBar();
-            $Output .= $LayoutObject->Notify( Info => 'Team imported!' );
+            $Output .= $LayoutObject->Notify( Info => Translatable('Team imported!') );
             $Output .= $LayoutObject->Output(
                 TemplateFile => 'AgentAppointmentTeam',
                 Data         => \%Param,

--- a/Kernel/Modules/AgentAppointmentTeam.pm
+++ b/Kernel/Modules/AgentAppointmentTeam.pm
@@ -252,7 +252,7 @@ sub Run {
         if ( ref $TeamData ne 'HASH' ) {
             return (
                 Message => Translatable('Couldn\'t read team configuration file.'),
-                Comment => Translatable('Please make sure you file is valid.'),
+                Comment => Translatable('Please make sure your file is valid.'),
             );
         }
 

--- a/Kernel/Modules/PublicCalendar.pm
+++ b/Kernel/Modules/PublicCalendar.pm
@@ -43,8 +43,8 @@ sub Run {
         $GetParam{$Needed} = $ParamObject->GetParam( Param => $Needed );
         if ( !$GetParam{$Needed} ) {
             return $LayoutObject->ErrorScreen(
-                Message => Translatable("No $Needed !"),
-                Comment => Translatable('Please contact the admin.'),
+                Message => $LayoutObject->{LanguageObject}->Translate( 'No %s!', $Needed ),
+                Comment => Translatable('Please contact the administrator.'),
             );
         }
     }
@@ -57,7 +57,7 @@ sub Run {
     if ( !%User ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No such user!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -70,14 +70,14 @@ sub Run {
     if ( !%Calendar ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('No permission!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
     if ( $Calendar{ValidID} != 1 ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('Invalid calendar!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -90,7 +90,7 @@ sub Run {
     if ( $AccessToken ne $GetParam{Token} ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('Invalid URL!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 
@@ -103,7 +103,7 @@ sub Run {
     if ( !$ICalString ) {
         return $LayoutObject->ErrorScreen(
             Message => Translatable('There was an error exporting the calendar!'),
-            Comment => Translatable('Please contact the admin.'),
+            Comment => Translatable('Please contact the administrator.'),
         );
     }
 

--- a/Kernel/Output/HTML/LinkObject/Appointment.pm
+++ b/Kernel/Output/HTML/LinkObject/Appointment.pm
@@ -405,19 +405,19 @@ sub SearchOptionList {
     my @SearchOptionList = (
         {
             Key  => 'CalendarName',
-            Name => 'Calendar Name',
+            Name => Translatable('Calendar Name'),
             Type => 'Text',
         },
         {
             Prefix => 'Start',
             Key    => 'StartTime',
-            Name   => 'Start Time',
+            Name   => Translatable('Start Time'),
             Type   => 'TimeLong',
         },
         {
             Prefix => 'End',
             Key    => 'EndTime',
-            Name   => 'End Time',
+            Name   => Translatable('End Time'),
             Type   => 'TimeLong',
         },
     );

--- a/Kernel/Output/HTML/Templates/Standard/AgentAppointmentEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentAppointmentEdit.tt
@@ -135,7 +135,7 @@
 [% IF Data.PermissionLevel < 2 %]
             <div class="Field">
 [% IF Data.ParentID %]
-                [% Translate("This an ocurrence of a repeating appointment.") | html %]<br>
+                [% Translate("This an occurrence of a repeating appointment.") | html %]<br>
                 <a href="#" id="EditParent">[% Translate("Click here to see the parent appointment.") | html %]</a>
 [% ELSE %]
                 <p id="RecurrenceType" class="ReadOnlyValue">[% Data.RecurrenceValue | html %]</p>
@@ -144,7 +144,7 @@
 [% ELSE %]
 [% IF Data.ParentID %]
             <div class="Field">
-                [% Translate("This an ocurrence of a repeating appointment.") | html %]<br>
+                [% Translate("This an occurrence of a repeating appointment.") | html %]<br>
                 <a href="#" id="EditParent">[% Translate("Click here to edit the parent appointment.") | html %]</a>
             </div>
 [% ELSE %]

--- a/OTRSAppointmentCalendar.sopm
+++ b/OTRSAppointmentCalendar.sopm
@@ -8,6 +8,7 @@
     <URL>http://otrs.org/</URL>
     <License>GNU AFFERO GENERAL PUBLIC LICENSE Version 3, November 2007</License>
     <Description Lang="en">The Appointment Calendar package.</Description>
+    <Description Lang="hu">Az értekezlet naptár csomag.</Description>
     <Filelist>
         <File Permission="660" Location="Kernel/Config/Files/OTRSAppointmentCalendar.xml"/>
         <File Permission="660" Location="Kernel/cpan-lib/Class/ReturnValue.pm"/>
@@ -143,6 +144,20 @@
         <br/>
         Si usted desinstala este paquete, todas las tablas de la base de datos creadas durante la instalación serán borradas.
         ¡Todos los datos de esas tablas serán irrevocablemente perdidos!.
+        <br/>
+        <br/>
+        ((enjoy))<br/>
+        <br/>
+
+    ]]></IntroUninstall>
+    <IntroUninstall Type="pre" Title="Eltávolítási információk" Lang="hu"><![CDATA[
+
+        <br/>
+        <strong>FIGYELEM</strong>
+        <br/>
+        <br/>
+        Ha eltávolítja ezt a csomagot, akkor a telepítés során létrehozott összes adatbázistábla törlésre kerül.
+        Az ezekben a táblákban lévő összes adat visszavonhatatlanul el fog veszni!
         <br/>
         <br/>
         ((enjoy))<br/>


### PR DESCRIPTION
Hi @mgruner 
This PR marks more strings as translatable, and fixes some typos. It also adds Hungarian entries to the .sopm file. Please sync again with Transifex, and add "Kernel/Language/hu_OTRSAppointmentCalendar.pm" entry to the .sopm (as the Hungarian translation of this module is done on Transifex).