### PR TITLE
Marked Location hover as translatable

### DIFF
--- a/Kernel/Output/HTML/Templates/Standard/AgentAppointmentEdit.tt
+++ b/Kernel/Output/HTML/Templates/Standard/AgentAppointmentEdit.tt
@@ -59,7 +59,7 @@
                 <input type="text" id="Location" name="Location" value="[% Data.Location | html %]" class="W50pc" />
 [% END %]
 [% RenderBlockStart("LocationLink") %]
-                <a class="LocationLink Hidden [% Data.CSSClass | html %]" href="[% Data.URL | html %][% Data.Location | uri %]" data-base-url="[% Data.URL | html %]" title="[% Data.Text | html %]" target="[% Data.Target | html %]">
+                <a class="LocationLink Hidden [% Data.CSSClass | html %]" href="[% Data.URL | html %][% Data.Location | uri %]" data-base-url="[% Data.URL | html %]" title="[% Data.Text | Translate | html %]" target="[% Data.Target | html %]">
                     <i class="fa [% Data.IconName | html %]"></i>
                 </a>
 [% RenderBlockEnd("LocationLink") %]


### PR DESCRIPTION
Hi @dvuckovic 
When you hover the mouse over the globe icon in an appointment overview, the string "Location" is displayed. I hope, this patch makes it possible to translate.